### PR TITLE
test: fix error that would occur in some machines sdue to execution order

### DIFF
--- a/test/Looplex.DotNet.Middlewares.ScimV2.UnitTests/Services/ResourceTypeServiceTests.cs
+++ b/test/Looplex.DotNet.Middlewares.ScimV2.UnitTests/Services/ResourceTypeServiceTests.cs
@@ -100,11 +100,13 @@ public class ResourceTypeServiceTests
         };
         _context.State.ResourceType = resourceType;
 
+        var count = ResourceTypeService.ResourceTypes.Count;
+
         // Act
         await _resourceTypeService.CreateAsync(_context, _cancellationToken);
 
         // Assert
-        Assert.AreEqual(1, ResourceTypeService.ResourceTypes.Count);
-        Assert.AreEqual("newResource", ResourceTypeService.ResourceTypes.First().Id);
+        Assert.AreEqual(1 + count, ResourceTypeService.ResourceTypes.Count);
+        Assert.AreEqual("newResource", ResourceTypeService.ResourceTypes.Last().Id);
     }
 }


### PR DESCRIPTION
an error was occuring beacause of the use of an static variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved test assertions for adding a new resource type to ensure accurate validation.
	- Enhanced verification for the last resource type in the list after addition.

- **Tests**
	- Updated the `CreateAsync_ShouldAddResourceTypeToList` test method for better dynamic validation.
	- Maintained the existing logic for the `GetByIdAsync_ShouldThrowException_WhenIdDoesNotExist` test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->