### PR TITLE
test: AB#28582 test for count and startindex verification

### DIFF
--- a/test/Looplex.DotNet.Middlewares.ScimV2.UnitTests/Middlewares/PaginationMiddlewareTests.cs
+++ b/test/Looplex.DotNet.Middlewares.ScimV2.UnitTests/Middlewares/PaginationMiddlewareTests.cs
@@ -41,35 +41,91 @@ namespace Looplex.DotNet.Middlewares.ScimV2.UnitTests.Middlewares
 
         }
 
+
+
         [TestMethod]
-        public  async Task PaginationMiddleware_Should_Throw_Exception()
+    public async Task PaginationMiddleware_Should_Throw_Exception_When_Count_Is_Zero()
+    {
+        // Arrange
+        _context.State.HttpContext.Request.QueryString = 
+            new QueryString("?startIndex=10&count=0");
+
+        // Act & Assert
+        var act = () => ScimV2Middlewares.PaginationMiddleware(_context, CancellationToken.None, _next);
+        
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("Param count is not valid");
+    }
+
+    [TestMethod]
+    public async Task PaginationMiddleware_Should_Throw_Exception_When_StartIndex_Is_Zero()
+    {
+        // Arrange
+        _context.State.HttpContext.Request.QueryString = 
+            new QueryString("?startIndex=0&count=10");
+
+        // Act & Assert
+        var act = () => ScimV2Middlewares.PaginationMiddleware(_context, CancellationToken.None, _next);
+        
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("Param startIndex is not valid");
+    }
+
+
+        [TestMethod]
+        public async Task PaginationMiddleware_Should_Throw_Exception_When_Count_Is_Negative_Value()
         {
-
-            // Arrange for invalid count
-
-            HttpContext httpContext = _context.State.HttpContext;
-
-            httpContext.Request.QueryString = new QueryString("?startIndex=1&count=0");
+            // Arrange
+            _context.State.HttpContext.Request.QueryString =
+                new QueryString("?startIndex=10&count=-1");
 
             // Act & Assert
+            var act = () => ScimV2Middlewares.PaginationMiddleware(_context, CancellationToken.None, _next);
 
-            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
-                 await ScimV2Middlewares.PaginationMiddleware(_context, CancellationToken.None, _next)
-            );
+            await act.Should().ThrowAsync<ArgumentException>()
+                .WithMessage("Param count is not valid");
+        }
 
-            Assert.AreEqual("Param count is not valid", ex.Message);
-
-            // Arrange for invalid startIndex
-
-            httpContext.Request.QueryString = new QueryString("?startIndex=0&count=10");
+        [TestMethod]
+        public async Task PaginationMiddleware_Should_Throw_Exception_When_StartIndex_Is_Negative_Value()
+        {
+            // Arrange
+            _context.State.HttpContext.Request.QueryString =
+                new QueryString("?startIndex=-5&count=10");
 
             // Act & Assert
+            var act = () => ScimV2Middlewares.PaginationMiddleware(_context, CancellationToken.None, _next);
 
-            ex = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
-                 await ScimV2Middlewares.PaginationMiddleware(_context, CancellationToken.None, _next)
-            );
+            await act.Should().ThrowAsync<ArgumentException>()
+                .WithMessage("Param startIndex is not valid");
+        }
 
-            Assert.AreEqual("Param startIndex is not valid", ex.Message);
+        [TestMethod]
+        public async Task PaginationMiddleware_Should_Throw_Exception_When_Count_Is_Not_Integer()
+        {
+            // Arrange
+            _context.State.HttpContext.Request.QueryString =
+                new QueryString("?startIndex=10&count=abc");
+
+            // Act & Assert
+            var act = () => ScimV2Middlewares.PaginationMiddleware(_context, CancellationToken.None, _next);
+
+            await act.Should().ThrowAsync<ArgumentException>()
+                .WithMessage("Param count is not valid");
+        }
+
+        [TestMethod]
+        public async Task PaginationMiddleware_Should_Throw_Exception_When_StartIndex_Is_Not_Integer()
+        {
+            // Arrange
+            _context.State.HttpContext.Request.QueryString =
+                new QueryString("?startIndex=-5&count=10.75");
+
+            // Act & Assert
+            var act = () => ScimV2Middlewares.PaginationMiddleware(_context, CancellationToken.None, _next);
+
+            await act.Should().ThrowAsync<ArgumentException>()
+                .WithMessage("Param startIndex is not valid");
         }
     }
 }

--- a/test/Looplex.DotNet.Middlewares.ScimV2.UnitTests/Middlewares/PaginationMiddlewareTests.cs
+++ b/test/Looplex.DotNet.Middlewares.ScimV2.UnitTests/Middlewares/PaginationMiddlewareTests.cs
@@ -1,0 +1,75 @@
+﻿using FluentAssertions;
+using Looplex.DotNet.Core.Application.Abstractions.Services;
+using Looplex.DotNet.Middlewares.ScimV2.Domain;
+using Looplex.DotNet.Middlewares.ScimV2.Middlewares;
+using Looplex.DotNet.Middlewares.ScimV2.Providers;
+using Looplex.OpenForExtension.Abstractions.Contexts;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using RestSharp;
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Looplex.DotNet.Middlewares.ScimV2.UnitTests.Middlewares
+{
+    [TestClass]
+    public class PaginationMiddlewareTests
+    {
+        private IScimV2Context _context = null!;
+        private Func<Task> _next = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            // Mock dependencies
+            _context = Substitute.For<IScimV2Context>();
+            dynamic state = new ExpandoObject();
+            state.HttpContext = new DefaultHttpContext();
+            _context.State.Returns(state);
+
+            // Set up the next middleware delegate
+            _next = Substitute.For<Func<Task>>();
+
+        }
+
+        [TestMethod]
+        public  async Task PaginationMiddleware_Should_Throw_Exception()
+        {
+
+            // Arrange for invalid count
+
+            HttpContext httpContext = _context.State.HttpContext;
+
+            httpContext.Request.QueryString = new QueryString("?startIndex=1&count=0");
+
+            // Act & Assert
+
+            var ex = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+                 await ScimV2Middlewares.PaginationMiddleware(_context, CancellationToken.None, _next)
+            );
+
+            Assert.AreEqual("Param count is not valid", ex.Message);
+
+            // Arrange for invalid startIndex
+
+            httpContext.Request.QueryString = new QueryString("?startIndex=0&count=10");
+
+            // Act & Assert
+
+            ex = await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+                 await ScimV2Middlewares.PaginationMiddleware(_context, CancellationToken.None, _next)
+            );
+
+            Assert.AreEqual("Param startIndex is not valid", ex.Message);
+        }
+    }
+}


### PR DESCRIPTION
count and startindex must be integers greater than 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Expanded unit tests for pagination middleware to verify error handling for various invalid pagination parameters, including negative values and non-integer inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->